### PR TITLE
Resolve illegal instructions w/ macOS Clang

### DIFF
--- a/src/lattice.h
+++ b/src/lattice.h
@@ -58,6 +58,8 @@ protected:
   void addFace(const int vertexIndex, const int faceIndex, const vstr &directions, const vint &signs);
 
 public:
+  virtual ~Lattice() = default;
+
   cartesian4 indexToCoordinate(const int vertexIndex);
   int coordinateToIndex(const cartesian4 &coordinate);
   int findFace(vint &vertices);


### PR DESCRIPTION
The tests would fail when compiled with macOS Clang. It turned out the fix was to just declare an explicit virtual destructor for the Lattice class. 